### PR TITLE
cert manager migrate to azure workload identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,4 @@ Examples for this module along with various configurations can be found in the [
 | 2025-12-24 | v2.0.9  | Federated identity credential setup in downstream platform-infrastructure module    |
 | 2026-01-06 | v2.1.0  | Add additional permissions for velero operations in platform-infrastructure module  |  
 | 2026-01-08 | v2.1.1  | Federated identity credential setup in for cert manager in downstream module        |                                                                   |
+| 2026-01-09 | v2.1.2  | Pass oidc issuer url for cert manager workload identity in downstream module        |

--- a/README.md
+++ b/README.md
@@ -122,4 +122,5 @@ Examples for this module along with various configurations can be found in the [
 | 2025-12-08 | v2.0.7  | Added support for `os_sku` to node pools.                                           |
 | 2025-12-08 | v2.0.8  | Enables workload identity by default in the downstream AKS module                   |
 | 2025-12-24 | v2.0.9  | Federated identity credential setup in downstream platform-infrastructure module    |
-| 2026-01-06 | v2.1.0  | Add additional permissions for velero operations in platform-infrastructure module  |                                                                     |
+| 2026-01-06 | v2.1.0  | Add additional permissions for velero operations in platform-infrastructure module  |  
+| 2026-01-08 | v2.1.1  | Federated identity credential setup in for cert manager in downstream module        |                                                                   |

--- a/platform_infrastructure.tf
+++ b/platform_infrastructure.tf
@@ -7,7 +7,7 @@ locals {
 # https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure
 #
 module "platform_infrastructure" {
-  source = "git::https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure.git?ref=v2.0.4"
+  source = "git::https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure.git?ref=v2.0.5"
 
   azure_resource_attributes = var.azure_resource_attributes
   naming_convention         = var.naming_convention

--- a/platform_infrastructure.tf
+++ b/platform_infrastructure.tf
@@ -7,7 +7,7 @@ locals {
 # https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure
 #
 module "platform_infrastructure" {
-  source = "git::https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure.git?ref=feat/cert-manager-migrate-to-azure-workload-identity"
+  source = "git::https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure.git?ref=v2.0.6"
 
   azure_resource_attributes = var.azure_resource_attributes
   naming_convention         = var.naming_convention

--- a/platform_infrastructure.tf
+++ b/platform_infrastructure.tf
@@ -7,7 +7,7 @@ locals {
 # https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure
 #
 module "platform_infrastructure" {
-  source = "git::https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure.git?ref=v2.0.5"
+  source = "git::https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure.git?ref=feat/cert-manager-migrate-to-azure-workload-identity"
 
   azure_resource_attributes = var.azure_resource_attributes
   naming_convention         = var.naming_convention


### PR DESCRIPTION
- This PR fixes the missing `oidc_issuer_url  ` variable in the downstream module repo [terraform-aurora-azure-environment-platform-infrastructure](https://github.com/gccloudone-aurora-iac/terraform-aurora-azure-environment-platform-infrastructure/pull/6)